### PR TITLE
add ignorePrefixes flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /release
 
 /coverage.txt
+
+.idea

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ commands = ["npm run lint"]
 [[watch]]
 name = "tests"
 paths = ["src", "tests"]
+ignorePrefixes=["vendor"] # ignore "src/vendor/*" and "tests/vendor/*" 
 commands = ["npm run test"]
 ```

--- a/main.go
+++ b/main.go
@@ -1,25 +1,17 @@
 package main
 
 import (
+	"log"
+
+	"github.com/Enapiuz/multiwatch/types"
+
 	"github.com/BurntSushi/toml"
 	"github.com/Enapiuz/multiwatch/printer"
 	"github.com/Enapiuz/multiwatch/watcher"
-	"log"
 )
 
-type DirectoryConfig struct {
-	Name     string
-	Paths    []string
-	Commands []string
-}
-
-type Config struct {
-	Delay int32
-	Watch []DirectoryConfig
-}
-
 func main() {
-	var config Config
+	var config types.Config
 	var watchers = make([]*watcher.Watcher, 0)
 	needReprint := make(chan bool)
 	_, err := toml.DecodeFile("multiwatch.toml", &config)
@@ -27,7 +19,7 @@ func main() {
 		log.Fatal(err)
 	}
 	for _, watchConfig := range config.Watch {
-		dirWatcher := watcher.NewWatcher(watchConfig.Name, watchConfig.Paths, watchConfig.Commands)
+		dirWatcher := watcher.NewWatcher(watchConfig)
 		dirWatcher.Run(needReprint)
 		watchers = append(watchers, dirWatcher)
 	}

--- a/multiwatch.toml
+++ b/multiwatch.toml
@@ -7,5 +7,6 @@ commands = ["sleep 1", "sleep 1", "ls /sfsdfsdf"]
 
 [[watch]]
 name = "tests"
-paths = ["vendor/golang.org"]
+paths = ["vendor/github.com"]
+ignorePrefixes = ["fsnotify"]
 commands = ["sleep 5"]

--- a/multiwatch.toml
+++ b/multiwatch.toml
@@ -7,6 +7,6 @@ commands = ["sleep 1", "sleep 1", "ls /sfsdfsdf"]
 
 [[watch]]
 name = "tests"
-paths = ["vendor/github.com"]
-ignorePrefixes = ["fsnotify"]
+paths = ["."]
+ignorePrefixes = ["vendor"]
 commands = ["sleep 5"]

--- a/types/config.go
+++ b/types/config.go
@@ -1,0 +1,13 @@
+package types
+
+type DirectoryConfig struct {
+	Name           string
+	Paths          []string
+	IgnorePrefixes []string
+	Commands       []string
+}
+
+type Config struct {
+	Delay int32
+	Watch []DirectoryConfig
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -92,14 +92,25 @@ func (w *Watcher) registerFiles() error {
 func (w *Watcher) watchDir(baseDir string) func(path string, fi os.FileInfo, err error) error {
 	return func(path string, fi os.FileInfo, err error) error {
 		if fi.Mode().IsDir() {
+			// check absolute path
+			absPath, err := filepath.Abs(path)
+			if err != nil {
+				return err
+			}
+
 			// check ignore prefixes
+			absBaseDir, err := filepath.Abs(baseDir)
+			if err != nil {
+				return err
+			}
+
 			for _, ignorePrefix := range w.config.IgnorePrefixes {
-				targetPath := fmt.Sprintf("%s/%s", baseDir, ignorePrefix)
-				if strings.HasPrefix(path, targetPath) {
+				targetPath := fmt.Sprintf("%s/%s", absBaseDir, ignorePrefix)
+				if strings.HasPrefix(absPath, targetPath) {
 					return nil
 				}
 			}
-			return w.watcher.Add(path)
+			return w.watcher.Add(absPath)
 		}
 		return nil
 	}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -2,12 +2,19 @@ package watcher
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/Enapiuz/multiwatch/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWatcher_GetStatus(t *testing.T) {
-	watcher := NewWatcher("testwatcher", []string{"../watcher"}, []string{""})
+	conf := types.DirectoryConfig{
+		Name:     "testwatcher",
+		Paths:    []string{"../watcher"},
+		Commands: []string{""},
+	}
+	watcher := NewWatcher(conf)
 	status := watcher.GetStatus()
 	expected := fmt.Sprintf("%s %s", "⚪", "testwatcher")
 	assert.Equal(t, expected, status, "wrong default status")


### PR DESCRIPTION
fsnotify returns ERROR `too many open files` when it watch many files.
so I added `ignorePrefixes` flag to make easy to set watch files.

For example, you can test this project following setting.
```
[[watch]]
name = "test"
paths = ["."]
ignorePrefixes = ["vendor"]
commands = ["go test github.com/Enapiuz/multiwatch/watcher "]
```
