### PR TITLE
add breakOnFail flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ commands = ["npm run lint"]
 name = "tests"
 paths = ["src", "tests"]
 ignorePrefixes=["vendor"] # ignore "src/vendor/*" and "tests/vendor/*" 
-commands = ["npm run test"]
+commands = ["npm run test", "npm run build"]
+breakOnFail = true # if tests will fail, build won't be run
 ```
 
 ## Donation
-If you enjoying this tool, feel free to buy me a coffee 😉
+If you are enjoying this tool, feel free to buy me a coffee 😉
 
 <a href="https://www.buymeacoffee.com/enapiuz" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: auto !important;width: auto !important;" ></a>

--- a/multiwatch.toml
+++ b/multiwatch.toml
@@ -24,4 +24,5 @@ commands = ["make imports"]
 name = "something"
 paths = ["vendor/github.com"]
 ignorePrefixes = ["vendor"]
-commands = ["sleep 1", "sleep 1", "ls /sfsdfsdf"]
+commands = ["sleep 1", "ls /1231231231", "sleep 1", "ls /sfsdfsdf"]
+breakOnFail = true

--- a/types/config.go
+++ b/types/config.go
@@ -6,6 +6,7 @@ type DirectoryConfig struct {
 	Paths          []string
 	IgnorePrefixes []string
 	Commands       []string
+	BreakOnFail    bool
 }
 
 // Config Application config

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -87,6 +87,9 @@ func (w *Watcher) runCommands() bool {
 		if err != nil {
 			w.errorLog += fmt.Sprintf("[%s]:\n%s%s", command, outBuffer.String(), errBuffer.String())
 			result = false
+			if w.config.BreakOnFail {
+				break
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
```
[[watch]]
name = "something"
paths = ["vendor/github.com"]
ignorePrefixes = ["vendor"]
commands = ["sleep 1", "ls /1231231231", "sleep 1", "ls /sfsdfsdf"]
breakOnFail = true
```

Only `sleep 1` and `ls /1231231231` will be executed because `ls` will fail.